### PR TITLE
Fixed Pacaur aliases

### DIFF
--- a/plugins/archlinux/archlinux.plugin.zsh
+++ b/plugins/archlinux/archlinux.plugin.zsh
@@ -28,8 +28,8 @@ if (( $+commands[yaourt] )); then
 fi
 
 if (( $+commands[pacaur] )); then
-  alias paupg='pacaur -Syua'
-  alias pasu='pacaur -Syua --noconfirm'
+  alias paupg='pacaur -Syu'
+  alias pasu='pacaur -Syu --noconfirm'
   alias pain='pacaur -S'
   alias pains='pacaur -U'
   alias pare='pacaur -R'


### PR DESCRIPTION
`pacaur -Syua` only updated AUR pakcages, wihch is incompatible with semantics of `pacupg` and `yaupg`. Removing `-a` here it would work for both main repos and aur.